### PR TITLE
Update inspec.yml

### DIFF
--- a/inspec.yml
+++ b/inspec.yml
@@ -3,7 +3,7 @@ copyright: Staggerlee011, 2021
 license: Apache-2.0
 summary: An InSpec Compliance Profile for AWS S3 Best Practices
 version: 0.1.0
-inspec_version: '~> 4'
+inspec_version: '>= 4'
 
 depends:
   - name: inspec-aws


### PR DESCRIPTION
Update to allow for versions of Inspec greater than 4.x. Currently utilizing the latest version of the Chef Inspec docker container which is at 5.x. 